### PR TITLE
Warnings + EOL FIX

### DIFF
--- a/link-title.py
+++ b/link-title.py
@@ -5,6 +5,8 @@ import re
 import requests
 import threading
 import hexchat
+import urllib3
+requests.packages.urllib3.disable_warnings()
 
 __module_name__ = "Link Title"
 __module_author__ = "PDog"
@@ -42,6 +44,7 @@ def print_title(url, chan, nick, mode):
             r.close()
             title = snarfer(html_doc)
             title = HTMLParser().unescape(title)
+            title = title.lstrip()
             msg = u"\0033\002::\003 Title:\002 {0} " + \
                   u"\0033\002::\003 URL:\002 \00318\037{1}\017 " + \
                   u"\0033\002::\003 Posted by:\002 {3}{2} " + \


### PR DESCRIPTION
- lines #8 and #9 are going to address an issue that causes warnings to be displayed in hexchat each time anyone posts a https link in chat
- line #47 will strip End Of Line out of website titles so that they will be shown in a single line. Can be useful because some websites (i.e. imgur.com albums) put some End Of Line characters at the beginning of page title, resulting in a ugly and confusing ECHO.