### PR TITLE
Extended title support

### DIFF
--- a/link-title.py
+++ b/link-title.py
@@ -31,8 +31,8 @@ def find_yt_script():
 
 def snarfer(html_doc):
     try:
-        h1 = html_doc[html_doc.index("<title")+6:html_doc.index("</title>")][:431]
-        snarf = h1[h1.index(">")+1:][:431]
+        snarf = html_doc[html_doc.index("<title")+6:html_doc.index("</title>")][:431]
+        snarf = snarf[snarf.index(">")+1:]
     except ValueError:
         snarf = ""
     return snarf

--- a/link-title.py
+++ b/link-title.py
@@ -31,7 +31,8 @@ def find_yt_script():
 
 def snarfer(html_doc):
     try:
-        snarf = html_doc[html_doc.index("<title>")+7:html_doc.index("</title>")][:431]
+        h1 = html_doc[html_doc.index("<title")+6:html_doc.index("</title>")][:431]
+        snarf = h1[h1.index(">")+1:][:431]
     except ValueError:
         snarf = ""
     return snarf


### PR DESCRIPTION
I have noticed some pages use attributes in their title tags. One example of this may be found [here](http://roma.corriere.it/notizie/cronaca/15_giugno_30/ex-portiere-sereni-condannato-3-anni-abusi-minori-151f406c-1f2d-11e5-be56-a3991da50b56.shtml?cmpid=SF020103COR&refresh_ce-cp) 
where the title tag is made like this:

    <title itemprop="name">title</title>

so the exception was being caught, hence displaying an empty title.

These two lines of code handle this case. I'm sure it's not the best way of doing it but it works.

EDIT: bad formatting, sorry. I suck at it.
EDIT 2: should be ok now