### PR TITLE
Same channel on multiple networks FIX

### DIFF
--- a/link-title.py
+++ b/link-title.py
@@ -36,7 +36,7 @@ def snarfer(html_doc):
         snarf = ""
     return snarf
 
-def print_title(url, chan, nick, mode):
+def print_title(url, chan, nick, mode, cont):
     try:
         r = requests.get(url, verify=False)
         if r.headers["content-type"].split("/")[0] == "text":
@@ -51,7 +51,7 @@ def print_title(url, chan, nick, mode):
                   u"\0033\002::\002"
             msg = msg.format(title, url, nick, mode)
             # Weird context and timing issues with threading, hence:
-            hexchat.command("TIMER 0.1 DOAT {0} ECHO {1}".format(chan, msg))
+            cont.command("TIMER 0.1 DOAT {0} ECHO {1}".format(chan, msg))
     except requests.exceptions.RequestException as e:
         print(e)
 
@@ -61,7 +61,8 @@ def event_cb(word, word_eol, userdata, attr):
         return
     
     word = [(word[i] if len(word) > i else "") for i in range(4)]
-    chan = hexchat.get_info("channel")
+    cur_context = hexchat.get_context()
+    chan = cur_context.get_info("channel")
     
     for w in word[1].split():
         stripped_word = hexchat.strip(w, -1, 3)
@@ -72,7 +73,7 @@ def event_cb(word, word_eol, userdata, attr):
             if url.endswith(","):
                 url = url[:-1]
                 
-            threading.Thread(target=print_title, args=(url, chan, word[0], word[2])).start()
+            threading.Thread(target=print_title, args=(url, chan, word[0], word[2], cur_context)).start()
 
     return hexchat.EAT_NONE
             


### PR DESCRIPTION
If anyone is on, let's say, #hexchat on freenode and #hexchat on snoonet, after a link is posted in chat, the title could get displayed on the wrong network.
The "chan" parameter in the print_title() function isn't enough: we need to know what server is that channel on, so carrying context is needed to show the title on the correct network.
This commit will fix it.